### PR TITLE
feat: add design tokens and default font

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,25 @@
 /** @type {import('tailwindcss').Config} */
+import defaultTheme from "tailwindcss/defaultTheme";
+
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: "#1E3A8A",
+        secondary: "#64748B",
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+      },
+      spacing: {
+        128: "32rem",
+        144: "36rem",
+      },
+      borderRadius: {
+        "4xl": "2rem",
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind theme with primary/secondary colors
- set Inter as default font
- add spacing and radius tokens for design charter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a49adec5808325815d2e84cb4173c0