### PR TITLE
refactor: centralize form components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -170,33 +170,33 @@ export default function BACSForm() {
           <label className="block mb-2 font-medium">Situations particulières</label>
           <div className="mb-4 space-y-1">
             <label className="block">
-              <input
+              <Input
                 type="checkbox"
                 checked={formData.heritage}
                 onChange={(e) =>
                   setFormData({ ...formData, heritage: e.target.checked })
                 }
-              />{" "}
+              />
               Bâtiment classé / patrimoine
             </label>
             <label className="block">
-              <input
+              <Input
                 type="checkbox"
                 checked={formData.technicalIssue}
                 onChange={(e) =>
                   setFormData({ ...formData, technicalIssue: e.target.checked })
                 }
-              />{" "}
+              />
               Impossibilité technique
             </label>
             <label className="block">
-              <input
+              <Input
                 type="checkbox"
                 checked={formData.roi}
                 onChange={(e) =>
                   setFormData({ ...formData, roi: e.target.checked })
                 }
-              />{" "}
+              />
               ROI estimé &gt; 10 ans (déclaratif)
             </label>
           </div>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-export default function Button({ className = "", ...props }) {
+export default function Button({ type = "button", className = "", ...props }) {
   return (
     <button
+      type={type}
       className={`px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 ${className}`}
       {...props}
     />

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -1,9 +1,15 @@
 import React from "react";
 
-export default function Input({ className = "", ...props }) {
+export default function Input({ type = "text", className = "", ...props }) {
+  const baseClasses =
+    type === "checkbox"
+      ? "mr-2 focus:ring-2 focus:ring-blue-500"
+      : "w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500";
+
   return (
     <input
-      className={`w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500 ${className}`}
+      type={type}
+      className={`${baseClasses} ${className}`}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- reuse a single Input component that applies shared Tailwind styles and handles checkboxes
- introduce a styled Button component with a default type
- swap raw checkbox inputs in App.jsx for the new Input component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49adeacf883259457300c60b40b5f