### PR TITLE
feat: extend theme with design tokens

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,24 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        primary: "#1D4ED8",
+        secondary: "#64748B",
+      },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
+      spacing: {
+        128: "32rem",
+        144: "36rem",
+      },
+      borderRadius: {
+        "4xl": "2rem",
+        "5xl": "2.5rem",
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- define primary and secondary colors
- set Inter as default sans font
- add spacing and radius tokens per design charter

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a497c9933c8325a1483d3d42b31f88