### PR TITLE
feat: add color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#0ea5e9" />
+    <meta name="theme-color" content="#1E88E5" />
     <title>BACS Checker — Décret BACS</title>
     <!-- Police premium (Inter) -->
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,10 +94,10 @@ export default function BACSForm() {
 
   return (
     <div className="max-w-4xl w-full mx-auto p-6 bg-white shadow-xl rounded-2xl">
-      <h1 className="text-2xl font-bold mb-1">
+      <h1 className="text-2xl font-bold mb-1 text-primary">
         Vérifiez si votre bâtiment est concerné par le décret BACS
       </h1>
-      <p className="text-sm text-gray-600 mb-6">
+      <p className="text-sm text-secondary mb-6">
         Module 1 (éligibilité) + Module 2 (diagnostic détaillé).
       </p>
 
@@ -327,14 +327,14 @@ export default function BACSForm() {
                       {roiYears === Infinity ? "—" : roiYears.toFixed(1)} an(s)
                     </strong>{" "}
                     {roiYears > 10 && (
-                      <span className="text-amber-600">(> 10 ans)</span>
+                      <span className="text-amber-600">(&gt; 10 ans)</span>
                     )}
                   </p>
                 </div>
               </div>
 
               {/* Plan d’actions */}
-              <div className="mb-4 p-3 bg-white border rounded">
+              <div className="mb-4 p-3 bg-secondary/10 border border-secondary/40 rounded">
                 <p className="font-semibold mb-1">Plan d’actions recommandé</p>
                 <ol className="list-decimal list-inside text-sm text-gray-700 space-y-1">
                   <li>Audit express : points de comptage, segmentation des zones, relevé protocoles existants.</li>

--- a/src/components/Input.jsx
+++ b/src/components/Input.jsx
@@ -3,8 +3,8 @@ import React from "react";
 export default function Input({ type = "text", className = "", ...props }) {
   const baseClasses =
     type === "checkbox"
-      ? "mr-2 focus:ring-2 focus:ring-blue-500"
-      : "w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500";
+      ? "mr-2 focus:ring-2 focus:ring-accent"
+      : "w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-accent";
 
   return (
     <input

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,8 +6,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: "#1E3A8A",
-        secondary: "#64748B",
+        primary: "#1E88E5",
+        secondary: "#8E24AA",
+        accent: "#FFC107",
       },
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans],


### PR DESCRIPTION
## Summary
- introduce vibrant primary, secondary, and accent colors
- apply new palette to heading, panels, and focus styles
- update theme color metadata

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4aa3b9fd08325af52df8975e7d712