### PR TITLE
feat: generate report without external API

### DIFF
--- a/src/services/reportGenerator.js
+++ b/src/services/reportGenerator.js
@@ -1,44 +1,47 @@
-export async function generateReport(reportData) {
-  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error("Clé API OpenAI manquante");
+export async function generateReport({
+  formData,
+  totalPower,
+  assujetti,
+  echeance,
+  statut,
+  gtb,
+  eco,
+  planActions,
+  derogations,
+}) {
+  const lines = [];
+
+  lines.push(`Bâtiment : ${formData.buildingName || "Non renseigné"}`);
+  lines.push(`Type : ${formData.buildingType || "Non renseigné"}`);
+  lines.push(`Puissance totale CVC : ${totalPower} kW`);
+  lines.push(`Statut : ${statut}`);
+  lines.push(`Échéance : ${echeance}`);
+
+  lines.push(
+    `GTB actuelle : ${gtb.currentClass} – ${gtb.classUpgrade}`
+  );
+
+  lines.push(
+    `CAPEX estimé : ${eco.capex.toFixed(0)} € | Économies : ${eco.annualSavingEuro.toFixed(
+      0
+    )} €/an | ROI : ${
+      Number.isFinite(eco.roiYears)
+        ? eco.roiYears.toFixed(1) + " ans"
+        : "non calculable"
+    }`
+  );
+
+  if (planActions && planActions.length) {
+    lines.push("\nPlan d'actions :");
+    planActions.forEach((a, i) => lines.push(`${i + 1}. ${a}`));
   }
 
-  try {
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: "gpt-4o",
-        messages: [
-          {
-            role: "system",
-            content:
-              "Tu es un assistant qui génère un rapport concis sur le décret BACS à partir des données fournies.",
-          },
-          {
-            role: "user",
-            content: `Génère un rapport synthétique basé sur les données suivantes:\n${JSON.stringify(
-              reportData,
-              null,
-              2
-            )}`,
-          },
-        ],
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Erreur API: ${response.status}`);
-    }
-
-    const data = await response.json();
-    return data.choices?.[0]?.message?.content?.trim();
-  } catch (error) {
-    console.error("Erreur lors de la génération du rapport:", error);
-    throw error;
+  if (derogations?.possible) {
+    lines.push("\nDérogations possibles :");
+    if (derogations.roi) lines.push("- ROI > 10 ans");
+    if (derogations.technical) lines.push("- Difficulté technique");
+    if (derogations.heritage) lines.push("- Patrimoine protégé");
   }
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- avoid external OpenAI dependency by generating report text locally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a57ca2afa88325b5d26d250ce12497